### PR TITLE
Exclude `property_key` value when no `primary_key` present in the query

### DIFF
--- a/lib/ar-find-in-batches-with-order.rb
+++ b/lib/ar-find-in-batches-with-order.rb
@@ -64,7 +64,7 @@ module ActiveRecord
           else
             # ...so in that case exclude the start entirely, rather than allow its
             # further inclusion, otherwise there is a chance of infinite looping
-            relation.where("#{sanitized_key} #{exclusive_comparison} ?". start)
+            relation.where("#{sanitized_key} #{exclusive_comparison} ?", start)
           end
 
         without_duplicates.to_a

--- a/lib/ar-find-in-batches-with-order.rb
+++ b/lib/ar-find-in-batches-with-order.rb
@@ -43,6 +43,11 @@ module ActiveRecord
         break if records_size < batch_size
 
         next_start = records.last.try(property_key)
+
+        if with_start_ids.none? && start == next_start
+          raise 'did not increment next start'
+        end
+
         with_start_ids.clear if start != next_start
         start = next_start
 

--- a/lib/ar-find-in-batches-with-order.rb
+++ b/lib/ar-find-in-batches-with-order.rb
@@ -44,10 +44,6 @@ module ActiveRecord
 
         next_start = records.last.try(property_key)
 
-        if with_start_ids.none? && start == next_start
-          raise 'did not increment next start'
-        end
-
         with_start_ids.clear if start != next_start
         start = next_start
 
@@ -72,7 +68,7 @@ module ActiveRecord
             relation.where("#{sanitized_key} #{exclusive_comparison} ?", start)
           end
 
-        without_duplicates.to_a
+        records = without_duplicates.to_a
       end
     end
 

--- a/lib/ar-find-in-batches-with-order.rb
+++ b/lib/ar-find-in-batches-with-order.rb
@@ -33,6 +33,7 @@ module ActiveRecord
         if !start
           relation
         else
+          # Note that for the initial query, always be inclusive of the start
           relation.where("#{sanitized_key} #{inclusive_comparison} ?", start)
         end.to_a
 
@@ -43,7 +44,6 @@ module ActiveRecord
         break if records_size < batch_size
 
         next_start = records.last.try(property_key)
-
         with_start_ids.clear if start != next_start
         start = next_start
 

--- a/lib/ar-find-in-batches-with-order/version.rb
+++ b/lib/ar-find-in-batches-with-order/version.rb
@@ -1,5 +1,5 @@
 module ActiveRecord
   module FindInBatchesWithOrder
-    VERSION = "0.1.0"
+    VERSION = "0.2.0"
   end
 end


### PR DESCRIPTION
Makes sure to exclude the `property_key` value entirely in the case where there are no IDs to key off of, so that `group by` queries which do not include an `id` column or `primary_key` for the relation in the results do not get stuck in an infinite query loop